### PR TITLE
fix(redis): Correct variable used for JSON serialization

### DIFF
--- a/dirt/src/main.rs
+++ b/dirt/src/main.rs
@@ -236,7 +236,7 @@ async fn main() -> anyhow::Result<()> {
                     tgt,
                 };
 
-                let json = serde_json::to_string(&serializable_event).unwrap();
+                let json = serde_json::to_string(&json_event).unwrap();
                 match con.rpush("dirt-events", json).await {
                     Ok(()) => {}
                     Err(e) => {


### PR DESCRIPTION
In main.rs, the code was attempting to serialize a non-existent variable 'serializable_event' instead of the correctly constructed 'json_event'.

This caused the JSON sent to Redis to have the wrong field name ('event' instead of 'db-event'). This commit corrects the variable name, ensuring the proper JSON format is sent to the 'dirt-events' Redis list.