### PR TITLE
Remove unreachable pattern warning in main.rs

### DIFF
--- a/dirt/src/main.rs
+++ b/dirt/src/main.rs
@@ -220,10 +220,6 @@ async fn main() -> anyhow::Result<()> {
                             continue;
                         }
                     },
-                    _ => {
-                        // All event types are handled, but this makes the match exhaustive
-                        continue;
-                    }
                 };
 
                 let json_event = JsonEvent {


### PR DESCRIPTION
The PR removes an unreachable `_` pattern in a `match` statement in `dirt/src/main.rs`. This silences a `unreachable_patterns` compiler warning. The match statement is now exhaustive, which is the preferred way to handle enums in Rust.

---
*PR created automatically by Jules for task [15118926983745516689](https://jules.google.com/task/15118926983745516689) started by @bobbintb*