### PR TITLE
fix: remove unreachable pattern warning in main.rs (#16)

### DIFF
--- a/dirt/src/main.rs
+++ b/dirt/src/main.rs
@@ -220,10 +220,6 @@ async fn main() -> anyhow::Result<()> {
                             continue;
                         }
                     },
-                    _ => {
-                        // All event types are handled, but this makes the match exhaustive
-                        continue;
-                    }
                 };
 
                 let json_event = JsonEvent {


### PR DESCRIPTION
Removed the redundant `_` catch-all pattern from the `EventType` match statement in `dirt/src/main.rs`. Since all variants of `EventType` are already handled explicitly, the `_` arm was unreachable, causing a compiler warning. Removing it makes the match exhaustive and idiomatic.