### PR TITLE
Update app version to 0.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,7 +322,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "dirt"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "aya",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "dirt-common"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "aya",
  "serde",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "dirt-ebpf"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "aya-ebpf",
  "aya-log-ebpf",

--- a/dirt-common/Cargo.toml
+++ b/dirt-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dirt-common"
-version = "0.1.0"
+version = "0.0.1"
 edition.workspace = true
 
 license.workspace = true

--- a/dirt-ebpf/Cargo.toml
+++ b/dirt-ebpf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dirt-ebpf"
-version = "0.1.0"
+version = "0.0.1"
 edition.workspace = true
 
 [dependencies]

--- a/dirt/Cargo.toml
+++ b/dirt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dirt"
-version = "0.1.0"
+version = "0.0.1"
 edition.workspace = true
 
 license.workspace = true


### PR DESCRIPTION
Changed the version from 0.1.0 to 0.0.1 in `dirt/Cargo.toml`, `dirt-common/Cargo.toml`, and `dirt-ebpf/Cargo.toml`, and updated `Cargo.lock` by running a build.

---
*PR created automatically by Jules for task [607123712159509870](https://jules.google.com/task/607123712159509870) started by @bobbintb*