### PR TITLE
Fix --help flag and move configuration check to the beginning of main…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ anyhow = { version = "1", default-features = false }
 # `std` feature is currently required to build `clap`.
 #
 # See https://github.com/clap-rs/clap/blob/61f5ee5/clap_builder/src/lib.rs#L15.
-clap = { version = "4.5.20", default-features = false, features = ["std"] }
+clap = { version = "4.5.20", default-features = false, features = ["std", "help"] }
 env_logger = { version = "0.11.5", default-features = false }
 libc = { version = "0.2.159", default-features = false }
 log = { version = "0.4.22", default-features = false }

--- a/dirt/src/main.rs
+++ b/dirt/src/main.rs
@@ -58,6 +58,20 @@ async fn main() -> anyhow::Result<()> {
     )
     .init();
 
+    let settings = match settings::load_settings() {
+        Ok(settings) => settings,
+        Err(e) => {
+            log::error!("Failed to load settings: {}", e);
+            return Err(e);
+        }
+    };
+
+    if settings.share.is_empty() {
+        let err_msg = "Configuration file is invalid or `share` list is empty.";
+        log::error!("{}", err_msg);
+        return Err(anyhow::anyhow!(err_msg));
+    }
+
     // Bump the memlock rlimit. This is needed for older kernels that don't use the
     // new memcg based accounting, see https://lwn.net/Articles/837122/
     let rlim = libc::rlimit {
@@ -104,20 +118,6 @@ async fn main() -> anyhow::Result<()> {
     if let Err(e) = aya_log::EbpfLogger::init(&mut ebpf) {
         // This can happen if you remove all log statements from your eBPF program.
         warn!("failed to initialize eBPF logger: {e}");
-    }
-
-    let settings = match settings::load_settings() {
-        Ok(settings) => settings,
-        Err(e) => {
-            log::error!("Failed to load settings: {}", e);
-            return Err(e);
-        }
-    };
-
-    if settings.share.is_empty() {
-        let err_msg = "Configuration file is invalid or `share` list is empty.";
-        log::error!("{}", err_msg);
-        return Err(anyhow::anyhow!(err_msg));
     }
 
     let mut whitelist: HashMap<_, ShareName, u8> =


### PR DESCRIPTION
…. (#21)

- Added the `help` feature to the `clap` dependency in the workspace `Cargo.toml`.
- Moved `settings::load_settings()` to the start of `main` in `dirt/src/main.rs` to provide earlier error feedback if the configuration is missing or invalid.